### PR TITLE
Fix: Resolve `RuntimeError` and update upstream repository

### DIFF
--- a/bug_fixes.md
+++ b/bug_fixes.md
@@ -33,7 +33,10 @@ This issue was caused by an incompatibility between recent versions of Python (3
 
 ### Fix
 
-The fix involved explicitly installing the `uvloop` event loop at the very beginning of the application's entry point (`bot/__main__.py`). By adding the following lines to the top of the file, we ensure that `uvloop` is installed before any other `asyncio`-dependent libraries are imported:
+The fix involved two steps:
+
+1.  **Updating the `UPSTREAM_REPO` in `update.py`:** The `update.py` script was configured to pull updates from the original `weebzone/Surf-TG` repository, which would overwrite any local changes. This was changed to `https://github.com/satyamisme/Surf-TG` to prevent the fix from being overwritten.
+2.  **Installing `uvloop` at startup:** The `uvloop` event loop is now explicitly installed at the very beginning of the application's entry point (`bot/__main__.py`). This ensures that `uvloop` is installed before any other `asyncio`-dependent libraries are imported, preventing the `RuntimeError`.
 
 ```python
 import uvloop
@@ -42,6 +45,7 @@ uvloop.install()
 
 ### Timeline
 
-- **2025-11-08:** Bug was reported and investigated.
-- **2025-11-08:** Root cause was identified as an event loop initialization issue.
-- **2025-11-08:** The fix was implemented and tested.
+- **2025-11-08:** Initial bug was reported and investigated.
+- **2025-11-08:** First fix was implemented, but was overwritten by the `update.py` script.
+- **2025-11-08:** The `update.py` script was fixed to point to the correct repository.
+- **2025-11-08:** The `uvloop` fix was re-applied.

--- a/update.py
+++ b/update.py
@@ -15,7 +15,7 @@ basicConfig(
 )
 load_dotenv('config.env', override=True)
 
-UPSTREAM_REPO = getenv('UPSTREAM_REPO', "https://github.com/weebzone/Surf-TG")
+UPSTREAM_REPO = getenv('UPSTREAM_REPO', "https://github.com/satyamisme/Surf-TG")
 UPSTREAM_BRANCH = getenv('UPSTREAM_BRANCH', "main")
 
 if UPSTREAM_REPO is not None:


### PR DESCRIPTION
This commit resolves a `RuntimeError: There is no current event loop in thread 'MainThread'` on application startup and corrects the upstream repository in the `update.py` script.

The `RuntimeError` was caused by an incompatibility between recent versions of Python, `asyncio`, and the `uvloop` event loop policy. The fix involves explicitly installing `uvloop` at the beginning of the application's entry point (`bot/__main__.py`) to ensure the event loop is initialized before any `asyncio`-dependent libraries are imported.

The `update.py` script was pointing to the original `weebzone/Surf-TG` repository, which would overwrite any local changes. This has been updated to point to the user's repository (`https://github.com/satyamisme/Surf-TG`) to prevent the fix from being overwritten.

Additionally, this commit adds a `bug_fixes.md` file to document the issue and the resolution for future reference.